### PR TITLE
feat: enable unlimited usage by removing quota limit enforcement

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -93,10 +93,8 @@ export async function POST(request: Request) {
     return jsonError(400, identityResult.errorCode ?? "INVALID_IDENTITY", identityResult.message ?? "Failed to resolve identity")
   }
 
-  const quota = await checkAndConsumeUsageQuota(identityResult.identity, "quick")
-  if (!quota.allowed) {
-    return jsonError(429, "DAILY_LIMIT_EXCEEDED", "오늘 생성 한도(10회)를 모두 사용했어요.", quota)
-  }
+  // ✅ 무제한 모드: quota 체크만 하고 차단하지 않음 (확인용)
+  await checkAndConsumeUsageQuota(identityResult.identity, "quick")
 
   const inputValidation = validateGenerateInput(payload)
   if (!inputValidation.valid || !inputValidation.data) {

--- a/app/api/planner/route.ts
+++ b/app/api/planner/route.ts
@@ -77,10 +77,8 @@ export async function POST(request: Request) {
     return jsonError(400, identityResult.errorCode ?? "INVALID_IDENTITY", identityResult.message ?? "Failed to resolve identity")
   }
 
-  const quota = await checkAndConsumeUsageQuota(identityResult.identity, "planner")
-  if (!quota.allowed) {
-    return jsonError(429, "DAILY_LIMIT_EXCEEDED", "오늘 생성 한도(10회)를 모두 사용했어요.", quota)
-  }
+  // ✅ 무제한 모드: quota 체크만 하고 차단하지 않음 (확인용)
+  await checkAndConsumeUsageQuota(identityResult.identity, "planner")
 
   try {
     const output = await generatePlan(input)

--- a/lib/usage/quota.ts
+++ b/lib/usage/quota.ts
@@ -127,16 +127,7 @@ export const checkAndConsumeUsageQuota = async (
     const safePlanner = Number.isFinite(plannerCount) && plannerCount > 0 ? plannerCount : 0
     const safeTotal = Number.isFinite(totalCount) && totalCount > 0 ? totalCount : 0
 
-    if (safeTotal >= DAILY_LIMIT) {
-      return {
-        allowed: false,
-        dailyLimit: DAILY_LIMIT,
-        usedCount: safeTotal,
-        remainingCount: 0,
-        dateKey,
-      }
-    }
-
+    // ✅ 무제한 모드: 카운트만 기록하고 제한 없음
     const nextQuick = feature === "quick" ? safeQuick + 1 : safeQuick
     const nextPlanner = feature === "planner" ? safePlanner + 1 : safePlanner
     const nextTotal = safeTotal + 1
@@ -157,6 +148,7 @@ export const checkAndConsumeUsageQuota = async (
       transaction.set(usageRef, payload)
     }
 
+    // ✅ 항상 allowed: true 반환 (무제한 사용)
     return {
       allowed: true,
       dailyLimit: DAILY_LIMIT,


### PR DESCRIPTION
- Remove daily limit check blocking in checkAndConsumeUsageQuota
- Keep usage counting for analytics but always return allowed: true
- Remove quota.allowed check in /api/generate and /api/planner
- Users can now use features unlimited times while usage is still tracked